### PR TITLE
Update command.ts to fix launch error on Win 10

### DIFF
--- a/client/src/command.ts
+++ b/client/src/command.ts
@@ -32,9 +32,13 @@ export function commandRunMG() {
     mgTerminal.show(preserveFocus);
     mgTerminal.sendText('quit');
     mgTerminal.sendText("cd " + "\"" + directory + "\"");
-    mgTerminal.sendText(mgPathName + fileName);
+    delay(10).then(()=>mgTerminal.sendText(mgPathName + fileName));
 
 };
+
+export function delay(time) {
+    return new Promise(resolve => setTimeout(resolve, time));
+  }
 
 export function commandCreateTemplate() {
     const templateUri = config.get("templateMotionGenesisPath", "CannotLoadConfig");


### PR DESCRIPTION
Added 10ms delay between directory change and call to MotionGenesis.exe to fix launch error :

![runMotionGenesis_errorMsg](https://user-images.githubusercontent.com/91970175/160297310-a63176b8-0fa6-4532-8a72-dc84b9aae18e.png)

Credits: Philippe Michaud