### PR TITLE
Missing space between "MotionGenesis" command and the file passed to it

### DIFF
--- a/client/src/command.ts
+++ b/client/src/command.ts
@@ -32,7 +32,7 @@ export function commandRunMG() {
     mgTerminal.show(preserveFocus);
     mgTerminal.sendText('quit');
     mgTerminal.sendText("cd " + "\"" + directory + "\"");
-    mgTerminal.sendText(mgPathName + fileName);
+    mgTerminal.sendText(mgPathName + " " + fileName);
 
 };
 


### PR DESCRIPTION
Issue: PS C:\MotionGenesis> cd "c:\MotionGenesis"
PS C:\MotionGenesis> MotionGenesisMGTemplateBasic.txt MotionGenesisMGTemplateBasic.txt : Le terme «MotionGenesisMGTemplateBasic.txt» n'est pas reconnu comme nom  d'applet de commande, fonction, fichier de script ou programme exécutable. Vérifiez l'orthographe du nom, ou si    un chemin d'accès existe, vérifiez que le chemin d'accès est correct et réessayez.
Au caractère Ligne:1 : 1                                                                                          + MotionGenesisMGTemplateBasic.txt